### PR TITLE
Apply scaling factor to get_gener_timeseries

### DIFF
--- a/HSP2/main.py
+++ b/HSP2/main.py
@@ -418,6 +418,8 @@ def get_gener_timeseries(ts: Dict, gener_instances: Dict, ddlinks: List) -> Dict
         if link.SVOL == 'GENER':
             gener = gener_instances[link.SVOLNO]
             series = gener.get_ts()
+            if link.MFACTOR != 1: 
+                series *= link.MFACTOR
             ts[f'{link.TMEMN}{link.TMEMSB1}{link.TMEMSB2}'] = series
     return ts
 


### PR DESCRIPTION
This fixing missing optional scaling factor that needs to be applied when reading data from Gener instances and passing to other module though the get_gener_timeseries function. 