### PR TITLE
Update LimnoTech from Respec Release; try again...

### DIFF
--- a/HSP2/GQUAL.py
+++ b/HSP2/GQUAL.py
@@ -648,6 +648,7 @@ def _gqual_(ui, ts):
 	if phflag == 1:
 		if 'PHVAL' not in ts:
 			errors[7] += 1  # ERRMSG7: timeseries not available
+			ts['PHVAL_GQ'] = zeros(simlen)
 		else:
 			ts['PHVAL_GQ'] = ts['PHVAL']
 	if roxfg == 1:
@@ -668,6 +669,7 @@ def _gqual_(ui, ts):
 	if phytfg == 1:
 		if 'PHYTO' not in ts:
 			errors[11] += 1  # ERRMSG11: timeseries not available
+			ts['PHYTO_GQ'] = zeros(simlen)
 		else:
 			ts['PHYTO_GQ'] = ts['PHYTO']
 

--- a/HSP2/__init__.py
+++ b/HSP2/__init__.py
@@ -1,5 +1,5 @@
 ''' Copyright (c) 2020 by RESPEC, INC.
-Author: Robert Heaphy, Ph.D.
+Authors: Robert Heaphy, Ph.D. and Paul Duda
 License: LGPL2
 '''
 
@@ -7,4 +7,5 @@ from HSP2.main import main
 from HSP2.mainDoE import main as mainDoE
 from HSP2.utilities import versions, flowtype
 
-__version__ = '0.9.1'  # Water Quality modules (0.9.0) plus new readWDM by block/group
+__version__ = '0.9.2'  # Optimizations with Numba, bug fixes, metric units, more precisely matching HSPF results
+                       # Water Quality modules (0.9.0) plus new readWDM by block/group (0.9.1)

--- a/tests/test_report_conversion.html
+++ b/tests/test_report_conversion.html
@@ -41,7 +41,7 @@
 <tr><td>-</td><td>COVINX</td><td>1.4901161193847656e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>NEGHTS</td><td>2.980232238769531e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>XLNMLT</td><td>1.0170042514801025e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>RDENPF</td><td>nan</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>RDENPF</td><td>1.2516975402832031e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>SKYCLR</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>SNOCOV</td><td>6.496906280517578e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>DULL</td><td>3.814697265625e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
@@ -94,19 +94,19 @@
 <tr><td>-</td><td>LGTMP</td><td>7.62939453125e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><th colspan=5 style="border:1px solid; background-color:#EEEEEE">PERLND_PWTGAS_001_2</th></tr>
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
-<tr><td>-</td><td>SOTMP</td><td>1.0000000150474662e+30</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>IOTMP</td><td>0.0612640380859375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>AOTMP</td><td>0.07028961181640625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>SODOX</td><td>1.0000000150474662e+30</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>SOCO2</td><td>1.0000000150474662e+30</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>SOTMP</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>IOTMP</td><td>7.62939453125e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>AOTMP</td><td>7.62939453125e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>SODOX</td><td>1.9073486328125e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>SOCO2</td><td>4.172325134277344e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>IODOX</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>IOCO2</td><td>3.725290298461914e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>AODOX</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>AOCO2</td><td>3.725290298461914e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>SOHT</td><td>0.012865066528320312</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>IOHT</td><td>3.969482421875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>AOHT</td><td>24.224609375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>POHT</td><td>24.3203125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>IOHT</td><td>0.030517578125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>AOHT</td><td>0.06640625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>POHT</td><td>0.0703125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>SODOXM</td><td>2.0279549062252045e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>SOCO2M</td><td>4.008143150713295e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>IODOXM</td><td>8.498318493366241e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
@@ -149,26 +149,26 @@
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
 <tr><td>-</td><td>AIRTMP</td><td>1.52587890625e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>DEWTMP</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>TW</td><td>0.00771331787109375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>IHEAT</td><td>65040.0</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>HTEXCH</td><td>450712.0</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>ROHEAT</td><td>35000.0</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>OHEAT  EXIT1</td><td>9916.0</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>OHEAT  EXIT2</td><td>26964.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>QTOTAL</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QSOLAR</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QLONGW</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QEVAP</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QCON</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QPREC</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QBED</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
+<tr><td>-</td><td>TW</td><td>0.00177001953125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>IHEAT</td><td>360.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>HTEXCH</td><td>31824.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>ROHEAT</td><td>22704.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>OHEAT  EXIT1</td><td>4804.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>OHEAT  EXIT2</td><td>24859.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QTOTAL</td><td>0.06175994873046875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QSOLAR</td><td>3.0517578125e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QLONGW</td><td>0.00189971923828125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QEVAP</td><td>0.01018524169921875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QCON</td><td>0.0031795501708984375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QPREC</td><td>0.0639190673828125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QBED</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><th colspan=5 style="border:1px solid; background-color:#EEEEEE">RCHRES_SEDTRN_001_2</th></tr>
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
-<tr><td>-</td><td>SSEDSAND</td><td>0.0063942674296814245</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>SSEDSAND</td><td>5.219435994519017e-14</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>SSEDSILT</td><td>1.9073486328125e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>SSEDCLAY</td><td>8.96453857421875e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>SSEDTOT</td><td>0.006394267376428786</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>RSEDSUSPSAND</td><td>0.0010785921277409842</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>SSEDTOT</td><td>8.96453857421875e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>RSEDSUSPSAND</td><td>8.838416110101832e-15</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDSUSPSILT</td><td>2.9802322387695312e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDSUSPCLAY</td><td>3.3974647521972656e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDSUSPTOT</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
@@ -185,82 +185,82 @@
 <tr><td>-</td><td>ISEDSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ISEDCLAY</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ISEDTOT</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>DEPSCOURSAND</td><td>0.0004296728481721539</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>DEPSCOURSAND</td><td>6.84001466577655e-15</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>DEPSCOURSILT</td><td>2.9802322387695312e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>DEPSCOURCLAY</td><td>7.101334631443024e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>DEPSCOURTOT</td><td>0.0004296728381119712</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>ROSEDSAND</td><td>1.557060539520409e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>DEPSCOURTOT</td><td>1.4901161193847656e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>ROSEDSAND</td><td>1.3838485479061857e-16</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ROSEDSILT</td><td>4.1314507370771025e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ROSEDCLAY</td><td>2.2118911147117615e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>ROSEDTOT</td><td>1.557060655710263e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>OSEDSANDEXIT1</td><td>7.287876862285364e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>ROSEDTOT</td><td>2.213346306234598e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>OSEDSANDEXIT1</td><td>5.963111948670274e-17</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>OSEDSILTEXIT1</td><td>4.1314507370771025e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>OSEDCLAYEXIT1</td><td>2.208980731666088e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>OSEDTOTEXIT1</td><td>7.287876835584961e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>OSEDSANDEXIT2</td><td>8.282729897160764e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>OSEDTOTEXIT1</td><td>2.2104359231889248e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>OSEDSANDEXIT2</td><td>7.877406409464993e-17</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>OSEDSILTEXIT2</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>OSEDCLAYEXIT2</td><td>5.440266293010865e-14</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>OSEDTOTEXIT2</td><td>8.282729266770317e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>OSEDTOTEXIT2</td><td>5.4409601824012555e-14</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><th colspan=5 style="border:1px solid; background-color:#EEEEEE">RCHRES_GQUAL_001_2</th></tr>
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
-<tr><td>-</td><td>PESTICIDE B4DQAL</td><td>0.0003209114074707031</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALSUSPSAND</td><td>1.0000000150474662e+30</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALSUSPSILT</td><td>3.129243850708008e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALSUSPCLAY</td><td>3.129243850708008e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALBEDSAND</td><td>1.5308614820241928e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DQAL</td><td>0.00018334388732910156</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALSUSPSAND</td><td>1.3271346688270569e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALSUSPSILT</td><td>1.7043203115463257e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALSUSPCLAY</td><td>1.7043203115463257e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALBEDSAND</td><td>1.0593794286251068e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQALBEDSILT</td><td>6.379559636116028e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALBEDCLAY</td><td>1.257285475730896e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RDQAL</td><td>0.00041961669921875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSAND</td><td>3.190085905328522e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSILT</td><td>6.556510925292969e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPCLAY</td><td>1.1965632438659668e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPTOT</td><td>1.1995434761047363e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDSAND</td><td>0.016357421875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALBEDCLAY</td><td>7.264316082000732e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RDQAL</td><td>0.0002498626708984375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSAND</td><td>2.625272740896297e-19</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSILT</td><td>2.980232238769531e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPCLAY</td><td>5.543231964111328e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPTOT</td><td>5.543231964111328e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDSAND</td><td>0.01123046875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4RSQALBEDSILT</td><td>0.0855712890625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDCLAY</td><td>0.0167236328125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDTOT</td><td>0.111083984375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTSAND</td><td>0.016357421875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDCLAY</td><td>0.0096435546875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDTOT</td><td>0.095458984375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTSAND</td><td>0.01123046875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4RSQALTOTSILT</td><td>0.0855712890625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTCLAY</td><td>0.0167236328125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTTOT</td><td>0.111083984375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RRQAL</td><td>0.111083984375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTCLAY</td><td>0.009521484375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTTOT</td><td>0.09521484375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RRQAL</td><td>0.09521484375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4IDQAL</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4ISQALSAND</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4ISQALSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4ISQALCLAY</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4ISQALTOT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4TIQAL</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALHYDROL</td><td>0.0021004676818847656</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALOXID</td><td>2.1010637283325195e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALPHOTOL</td><td>0.0019789114594459534</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALVOLAT</td><td>3.66999302059412e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALBIODEG</td><td>2.330634742975235e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALGEN</td><td>4.6622008085250854e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALTOT</td><td>0.0004973411560058594</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALHYDROL</td><td>0.00021457672119140625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALOXID</td><td>2.146698534488678e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALPHOTOL</td><td>5.827052518725395e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALVOLAT</td><td>1.0186340659856796e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALBIODEG</td><td>7.599592208862305e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALGEN</td><td>1.521781086921692e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALTOT</td><td>0.0002155303955078125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQDECSUSPSAND</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQDECSUSPSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQDECSUSPCLAY</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDSAND</td><td>7.424503564834595e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDSILT</td><td>5.912035703659058e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDCLAY</td><td>9.626150131225586e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDTOT</td><td>2.2798776626586914e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALSUSPSAND</td><td>1.4135318366241564e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALSUSPSILT</td><td>4.6938657760620117e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALSUSPCLAY</td><td>8.092960342764854e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALBEDSAND</td><td>0.0002548694610595703</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALBEDSILT</td><td>0.0003304481506347656</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALBEDCLAY</td><td>0.000370025634765625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALTOT</td><td>0.000583648681640625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DSQALSAND</td><td>2.5380944738660233e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DSQALSILT</td><td>2.1047890186309814e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DSQALCLAY</td><td>2.4418113753199577e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DSQALTOT</td><td>2.1606683731079102e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RODQAL</td><td>5.038455128669739e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALSAND</td><td>2.7056166072487563e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALSILT</td><td>7.579714633720869e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALCLAY</td><td>6.373738870024681e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALTOT</td><td>6.300979293882847e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4TROQAL</td><td>8.685421198606491e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDSAND</td><td>6.161630153656006e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDSILT</td><td>3.0621886253356934e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDCLAY</td><td>8.143484592437744e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDTOT</td><td>1.7374753952026367e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALSUSPSAND</td><td>2.6575658720103673e-19</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALSUSPSILT</td><td>2.868473529815674e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALSUSPCLAY</td><td>2.8479844331741333e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALBEDSAND</td><td>0.00022268295288085938</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALBEDSILT</td><td>0.0003616809844970703</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALBEDCLAY</td><td>0.0003204345703125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALTOT</td><td>0.00033283233642578125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DSQALSAND</td><td>4.656612873077393e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DSQALSILT</td><td>9.313225746154785e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DSQALCLAY</td><td>1.1175870895385742e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DSQALTOT</td><td>9.685754776000977e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RODQAL</td><td>4.516914486885071e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALSAND</td><td>3.448102383427296e-21</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALSILT</td><td>8.078870905592339e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALCLAY</td><td>5.871697794646025e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALTOT</td><td>5.871697794646025e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4TROQAL</td><td>4.544854164123535e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4ODQALEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
 <tr><td>-</td><td>PESTICIDE B4OSQALSAND1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
 <tr><td>-</td><td>PESTICIDE B4OSQALSILT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
@@ -493,112 +493,108 @@
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
 <tr><td>-</td><td>AIRTMP</td><td>1.52587890625e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>DEWTMP</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>TW</td><td>0.006622314453125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>IHEAT</td><td>9916.0</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>HTEXCH</td><td>492.1875</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>ROHEAT</td><td>9796.0</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>QTOTAL</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QSOLAR</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QLONGW</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QEVAP</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QCON</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QPREC</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QBED</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
+<tr><td>-</td><td>TW</td><td>0.0023956298828125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>IHEAT</td><td>4804.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>HTEXCH</td><td>209.46875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>ROHEAT</td><td>4852.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QTOTAL</td><td>0.042633056640625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QSOLAR</td><td>3.0517578125e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QLONGW</td><td>0.001903533935546875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QEVAP</td><td>0.01373291015625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QCON</td><td>0.004055023193359375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QPREC</td><td>0.0479583740234375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QBED</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><th colspan=5 style="border:1px solid; background-color:#EEEEEE">RCHRES_SEDTRN_002_2</th></tr>
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
-<tr><td>-</td><td>SSEDSAND</td><td>32233.880787849426</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>SSEDSAND</td><td>32.17578125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>SSEDSILT</td><td>8.741393685340881e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>SSEDCLAY</td><td>0.004822731018066406</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>SSEDTOT</td><td>3.022314549036573e+23</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>RSEDSUSPSAND</td><td>0.6044148650689749</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>SSEDTOT</td><td>32.17578125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>RSEDSUSPSAND</td><td>0.000594601035118103</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDSUSPSILT</td><td>4.018563259933217e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDSUSPCLAY</td><td>2.3756001610308886e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDSUSPTOT</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>RSEDBEDSAND</td><td>111.30940246582031</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>RSEDBEDSAND</td><td>0.006695747375488281</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDBEDSILT</td><td>9.5367431640625e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDBEDCLAY</td><td>9.5367431640625e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDBEDTOT</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>RSEDTOTSAND</td><td>111.3060578610748</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>RSEDTOTSAND</td><td>0.006666898727416992</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDTOTSILT</td><td>9.5367431640625e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDTOTCLAY</td><td>1.9073486328125e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>RSEDTOTTOT</td><td>111.30604934692383</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>BEDDEP</td><td>1.5331926047801971</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>ISEDSAND</td><td>7.287876862285364e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>RSEDTOTTOT</td><td>0.006664276123046875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>BEDDEP</td><td>9.22083854675293e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>ISEDSAND</td><td>5.963111948670274e-17</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ISEDSILT</td><td>4.1314507370771025e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ISEDCLAY</td><td>2.208980731666088e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ISEDTOT</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>DEPSCOURSAND</td><td>6.653984178672545</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>DEPSCOURSAND</td><td>0.006695747375488281</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>DEPSCOURSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>DEPSCOURCLAY</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>DEPSCOURTOT</td><td>6.653984178672545</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>ROSEDSAND</td><td>6.648462668410502</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>DEPSCOURTOT</td><td>0.006695747375488281</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>ROSEDSAND</td><td>0.006072282791137695</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ROSEDSILT</td><td>3.729283548636886e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ROSEDCLAY</td><td>2.208980731666088e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>ROSEDTOT</td><td>6.648462610435672</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>OSEDSANDEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>OSEDSILTEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>OSEDCLAYEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>OSEDTOTEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
+<tr><td>-</td><td>ROSEDTOT</td><td>0.006072282791137695</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><th colspan=5 style="border:1px solid; background-color:#EEEEEE">RCHRES_GQUAL_002_2</th></tr>
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
-<tr><td>-</td><td>PESTICIDE B4DQAL</td><td>0.06208173185586929</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALSUSPSAND</td><td>3.842661499220412e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALSUSPSILT</td><td>0.006096092010538623</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALSUSPCLAY</td><td>0.0060960929418611975</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALBEDSAND</td><td>1.0000000150474662e+30</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALBEDSILT</td><td>5.908378604077558e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALBEDCLAY</td><td>5.908378604077558e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RDQAL</td><td>3.326514342916198e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSAND</td><td>3.692891835171963e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSILT</td><td>1.1485989550986582e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPCLAY</td><td>9.39495445865992e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPTOT</td><td>3.689216669755524e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDSAND</td><td>3.0425593422478414e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDSILT</td><td>2.634677920276829e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDCLAY</td><td>2.634677920276829e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDTOT</td><td>3.0425593422478414e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTSAND</td><td>3.689972839993061e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTSILT</td><td>2.634677920276829e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTCLAY</td><td>9.39495445865992e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTTOT</td><td>3.6858282271623466e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RRQAL</td><td>9.393785148859024e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4IDQAL</td><td>5.047768354415894e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ISQALSAND</td><td>2.7056166072487563e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ISQALSILT</td><td>7.579714633720869e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ISQALCLAY</td><td>6.373738870024681e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ISQALTOT</td><td>6.300979293882847e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4TIQAL</td><td>8.685467764735222e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALHYDROL</td><td>5.078472895547748e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALOXID</td><td>5.078476306152879e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALPHOTOL</td><td>8.299172009174072e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALVOLAT</td><td>2.470102344886982e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALBIODEG</td><td>3.2698608265491202e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALGEN</td><td>6.539750074807671e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALTOT</td><td>3.2055831979960203e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DQAL</td><td>0.001027822494506836</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALSUSPSAND</td><td>1.4184479368850589e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALSUSPSILT</td><td>1.671724021434784e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALSUSPCLAY</td><td>1.6810372471809387e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALBEDSAND</td><td>1.9524312722118964e-14</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALBEDSILT</td><td>5.247972195698836e-15</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALBEDCLAY</td><td>5.247972195698836e-15</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RDQAL</td><td>4.807952791452408e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSAND</td><td>3.3322066883556545e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSILT</td><td>7.858158568296858e-13</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPCLAY</td><td>6.266418495215476e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPTOT</td><td>3.331660991534591e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDSAND</td><td>6.408762409648716e-13</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDSILT</td><td>2.340572180514755e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDCLAY</td><td>2.340572180514755e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDTOT</td><td>4.68114436102951e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTSAND</td><td>3.3322066883556545e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTSILT</td><td>2.340572180514755e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTCLAY</td><td>6.266418495215476e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTTOT</td><td>3.331115294713527e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RRQAL</td><td>4.842877388000488e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4IDQAL</td><td>4.516914486885071e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ISQALSAND</td><td>1.4330904112481204e-21</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ISQALSILT</td><td>8.078870905592339e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ISQALCLAY</td><td>5.871697794646025e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ISQALTOT</td><td>5.871697794646025e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4TIQAL</td><td>8.689425885677338e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALHYDROL</td><td>1.3210410543251783e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALOXID</td><td>1.3210454952172768e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALPHOTOL</td><td>1.5276148701559578e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALVOLAT</td><td>4.5508041779385167e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALBIODEG</td><td>1.2462120224654427e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALGEN</td><td>2.492419604038787e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALTOT</td><td>2.3828306439099833e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQDECSUSPSAND</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQDECSUSPSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQDECSUSPCLAY</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDSAND</td><td>1.6571298153134073e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDSILT</td><td>5.689063247728797e-14</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDCLAY</td><td>5.689063247728797e-14</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDTOT</td><td>1.6571298153134073e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALSUSPSAND</td><td>3.389161989453271e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDSAND</td><td>1.3692287592365765e-17</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDSILT</td><td>5.057803134644878e-17</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDCLAY</td><td>5.057803134644878e-17</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDTOT</td><td>1.0115606269289756e-16</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALSUSPSAND</td><td>3.2439857022836804e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4ADQALSUSPSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALSUSPCLAY</td><td>5.3899804175472354e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALBEDSAND</td><td>2.576709370316621e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALBEDSILT</td><td>2.5336893694216656e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALBEDCLAY</td><td>2.5336893694216656e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALTOT</td><td>3.393920964711583e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DSQALSAND</td><td>6.291869426725341e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALSUSPCLAY</td><td>4.195754854663392e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALBEDSAND</td><td>9.835882108788496e-14</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALBEDSILT</td><td>2.3385737790704297e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALBEDCLAY</td><td>2.3385737790704297e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALTOT</td><td>3.242894308641553e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DSQALSAND</td><td>6.408762409648716e-13</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4DSQALSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4DSQALCLAY</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DSQALTOT</td><td>6.291869426725341e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RODQAL</td><td>3.203866071999073e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALSAND</td><td>3.41015328686467e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALSILT</td><td>1.0630507166736923e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALCLAY</td><td>8.71699668566761e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALTOT</td><td>8.71699668566761e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4TROQAL</td><td>8.685095235705376e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DSQALTOT</td><td>6.408762409648716e-13</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RODQAL</td><td>4.3585896492004395e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALSAND</td><td>3.232707967981696e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALSILT</td><td>7.292833004157728e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALCLAY</td><td>5.8353180065751076e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALTOT</td><td>3.229797584936023e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4TROQAL</td><td>4.3958425521850586e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><th colspan=5 style="border:1px solid; background-color:#EEEEEE">RCHRES_OXRX_002_2</th></tr>
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
 <tr><td>-</td><td>DOXCONC</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
@@ -787,112 +783,108 @@
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
 <tr><td>-</td><td>AIRTMP</td><td>1.52587890625e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>DEWTMP</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>TW</td><td>0.010814666748046875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>IHEAT</td><td>26964.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>HTEXCH</td><td>1590.21875</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>ROHEAT</td><td>27028.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>QTOTAL</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QSOLAR</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QLONGW</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QEVAP</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QCON</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QPREC</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QBED</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
+<tr><td>-</td><td>TW</td><td>0.009113311767578125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>IHEAT</td><td>24859.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>HTEXCH</td><td>1590.21875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>ROHEAT</td><td>25128.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QTOTAL</td><td>0.053783416748046875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QSOLAR</td><td>1.52587890625e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QLONGW</td><td>0.009351730346679688</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QEVAP</td><td>0.02909088134765625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QCON</td><td>0.0227813720703125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QPREC</td><td>0.02070140838623047</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QBED</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><th colspan=5 style="border:1px solid; background-color:#EEEEEE">RCHRES_SEDTRN_003_2</th></tr>
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
-<tr><td>-</td><td>SSEDSAND</td><td>13159.623983383179</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>SSEDSAND</td><td>13.5986328125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>SSEDSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>SSEDCLAY</td><td>4.788169860603375e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>SSEDTOT</td><td>3.022314549036573e+23</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>RSEDSUSPSAND</td><td>0.6222592645208351</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>SSEDTOT</td><td>13.5986328125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>RSEDSUSPSAND</td><td>0.0006361901760101318</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDSUSPSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDSUSPCLAY</td><td>2.5943873785405636e-15</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDSUSPTOT</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>RSEDBEDSAND</td><td>111.17549133300781</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>RSEDBEDSAND</td><td>0.013062477111816406</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDBEDSILT</td><td>9.5367431640625e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDBEDCLAY</td><td>9.5367431640625e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDBEDTOT</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>RSEDTOTSAND</td><td>111.14605284435675</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>RSEDTOTSAND</td><td>0.013034820556640625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDTOTSILT</td><td>9.5367431640625e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDTOTCLAY</td><td>9.5367431640625e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>RSEDTOTTOT</td><td>111.14604949951172</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>BEDDEP</td><td>1.5313479602336884</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>ISEDSAND</td><td>8.282729897160764e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>RSEDTOTTOT</td><td>0.013034820556640625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>BEDDEP</td><td>0.0001799464225769043</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>ISEDSAND</td><td>7.877406409464993e-17</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ISEDSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ISEDCLAY</td><td>5.440266293010865e-14</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ISEDTOT</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>DEPSCOURSAND</td><td>12.499890524893999</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>DEPSCOURSAND</td><td>0.013062477111816406</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>DEPSCOURSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>DEPSCOURCLAY</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>DEPSCOURTOT</td><td>12.499890524893999</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>ROSEDSAND</td><td>12.069812903180718</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>DEPSCOURTOT</td><td>0.013062477111816406</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>ROSEDSAND</td><td>0.01239776611328125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ROSEDSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ROSEDCLAY</td><td>5.1807516610047344e-14</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>ROSEDTOT</td><td>12.069812903180718</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>OSEDSANDEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>OSEDSILTEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>OSEDCLAYEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>OSEDTOTEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
+<tr><td>-</td><td>ROSEDTOT</td><td>0.01239776611328125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><th colspan=5 style="border:1px solid; background-color:#EEEEEE">RCHRES_GQUAL_003_2</th></tr>
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
-<tr><td>-</td><td>PESTICIDE B4DQAL</td><td>0.00014328883844427764</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALSUSPSAND</td><td>1.162423934886192e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DQAL</td><td>3.925152122974396e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALSUSPSAND</td><td>1.048917397383775e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQALSUSPSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALSUSPCLAY</td><td>2.0585740720946433e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALBEDSAND</td><td>1.0000000150474662e+30</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALBEDSILT</td><td>1.4123730600313321e-14</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALBEDCLAY</td><td>1.4123730600313321e-14</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RDQAL</td><td>2.106591807660152e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSAND</td><td>2.3112026770188976e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALSUSPCLAY</td><td>1.0516941983951256e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALBEDSAND</td><td>6.556888365594205e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALBEDSILT</td><td>1.288980857813704e-15</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALBEDCLAY</td><td>1.288980857813704e-15</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RDQAL</td><td>1.4548511728662561e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSAND</td><td>2.0628476704587229e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4RSQALSUSPSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPCLAY</td><td>2.2846274561994455e-16</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPTOT</td><td>2.31120267424334e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDSAND</td><td>1.7180047662264543e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDSILT</td><td>6.298087485562265e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDCLAY</td><td>6.298087485562265e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDTOT</td><td>1.7179436779396484e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTSAND</td><td>2.3107794044907592e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTSILT</td><td>6.298087485562265e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTCLAY</td><td>6.298281774591574e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTTOT</td><td>2.3107034680114324e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RRQAL</td><td>1.0122744242835324e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4IDQAL</td><td>9.85528458841145e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ISQALSAND</td><td>1.6994623414698002e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPCLAY</td><td>1.6677946382539165e-19</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPTOT</td><td>2.0628476704587229e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDSAND</td><td>3.902433931557425e-14</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDSILT</td><td>5.747858786153692e-13</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDCLAY</td><td>5.747858786153692e-13</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDTOT</td><td>1.1495717572307385e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTSAND</td><td>2.063273996100179e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTSILT</td><td>5.747858786153692e-13</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTCLAY</td><td>5.747858786153692e-13</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTTOT</td><td>2.063487158920907e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RRQAL</td><td>1.4549662807894492e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4IDQAL</td><td>1.011467247735709e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ISQALSAND</td><td>2.0152187673323137e-21</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4ISQALSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ISQALCLAY</td><td>1.1251138638378871e-17</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ISQALTOT</td><td>1.6994623533417817e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4TIQAL</td><td>9.853465599007905e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALHYDROL</td><td>5.44102476851549e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALOXID</td><td>5.441016526219755e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALPHOTOL</td><td>6.372749510319409e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALVOLAT</td><td>1.7833179377646502e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALBIODEG</td><td>5.081579601551311e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALGEN</td><td>1.016314143953423e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALTOT</td><td>7.738278213764715e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ISQALCLAY</td><td>1.1551835334654148e-17</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ISQALTOT</td><td>1.1552258851127775e-17</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4TIQAL</td><td>1.011467247735709e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALHYDROL</td><td>8.123720363073517e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALOXID</td><td>8.12367950686621e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALPHOTOL</td><td>9.391399657943111e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALVOLAT</td><td>2.801581189260105e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALBIODEG</td><td>7.524891820764879e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALGEN</td><td>1.5049761437069265e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALTOT</td><td>1.4105580703471787e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQDECSUSPSAND</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQDECSUSPSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQDECSUSPCLAY</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDSAND</td><td>2.2695000989175328e-14</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDSILT</td><td>3.2948038460041504e-16</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDCLAY</td><td>3.2948038460041504e-16</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDTOT</td><td>2.269442140688646e-14</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALSUSPSAND</td><td>2.27721744294751e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDSAND</td><td>1.8735310002081056e-18</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDSILT</td><td>2.915474169559501e-17</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDCLAY</td><td>2.915474169559501e-17</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDTOT</td><td>5.830948339119002e-17</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALSUSPSAND</td><td>2.0628476704587229e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4ADQALSUSPSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALSUSPCLAY</td><td>8.647964226070275e-16</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALBEDSAND</td><td>1.5327315805446773e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALBEDSILT</td><td>5.845172327927084e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALBEDCLAY</td><td>5.845172327927084e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALTOT</td><td>2.27692644405586e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DSQALSAND</td><td>4.403891140643432e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALSUSPCLAY</td><td>3.8467207206166e-19</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALBEDSAND</td><td>3.902433931557425e-14</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALBEDSILT</td><td>5.593075915605317e-13</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALBEDCLAY</td><td>5.593075915605317e-13</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALTOT</td><td>2.063487158920907e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DSQALSAND</td><td>5.98436231125099e-15</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4DSQALSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4DSQALCLAY</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DSQALTOT</td><td>4.403891140643432e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RODQAL</td><td>2.0301376935094595e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALSAND</td><td>2.202355254277144e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DSQALTOT</td><td>5.98436231125099e-15</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RODQAL</td><td>9.63154889177531e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALSAND</td><td>1.9703350062627578e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4ROSQALSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALCLAY</td><td>2.3305064111362178e-14</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALTOT</td><td>2.2023550338978737e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4TROQAL</td><td>2.0366860553622246e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALCLAY</td><td>1.1000205127754785e-17</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALTOT</td><td>1.9703350062627578e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4TROQAL</td><td>9.63154889177531e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><th colspan=5 style="border:1px solid; background-color:#EEEEEE">RCHRES_OXRX_003_2</th></tr>
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
 <tr><td>-</td><td>DOXCONC</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
@@ -1081,112 +1073,108 @@
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
 <tr><td>-</td><td>AIRTMP</td><td>7.62939453125e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>DEWTMP</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>TW</td><td>0.00675201416015625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>IHEAT</td><td>34920.0</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>HTEXCH</td><td>6719.0</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>ROHEAT</td><td>31256.0</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>QTOTAL</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QSOLAR</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QLONGW</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QEVAP</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QCON</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QPREC</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QBED</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
+<tr><td>-</td><td>TW</td><td>0.002468109130859375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>IHEAT</td><td>23016.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>HTEXCH</td><td>3088.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>ROHEAT</td><td>19968.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QTOTAL</td><td>0.064483642578125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QSOLAR</td><td>3.0517578125e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QLONGW</td><td>0.002536773681640625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QEVAP</td><td>0.010477066040039062</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QCON</td><td>0.0048809051513671875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QPREC</td><td>0.058624267578125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QBED</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><th colspan=5 style="border:1px solid; background-color:#EEEEEE">RCHRES_SEDTRN_004_2</th></tr>
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
-<tr><td>-</td><td>SSEDSAND</td><td>1754.3592128753662</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>SSEDSAND</td><td>2.444732666015625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>SSEDSILT</td><td>1.2330710887908936e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>SSEDCLAY</td><td>0.005889892578125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>SSEDTOT</td><td>3.022314549036573e+23</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>RSEDSUSPSAND</td><td>4.108305153436959</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>SSEDTOT</td><td>2.444793701171875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>RSEDSUSPSAND</td><td>0.004007816314697266</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDSUSPSILT</td><td>4.830980060432921e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDSUSPCLAY</td><td>5.7800207287073135e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDSUSPTOT</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>RSEDBEDSAND</td><td>698.5816040039062</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>RSEDBEDSAND</td><td>0.0140380859375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDBEDSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDBEDCLAY</td><td>0.00043487548828125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDBEDTOT</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>RSEDTOTSAND</td><td>698.5823364257812</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>RSEDTOTSAND</td><td>0.01409912109375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDTOTSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDTOTCLAY</td><td>0.00043487548828125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>RSEDTOTTOT</td><td>698.5819244384766</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>BEDDEP</td><td>0.7998587042093277</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>ISEDSAND</td><td>12.052774801850319</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>RSEDTOTTOT</td><td>0.01434326171875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>BEDDEP</td><td>1.6450881958007812e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>ISEDSAND</td><td>0.01239776611328125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ISEDSILT</td><td>3.729283548636886e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ISEDCLAY</td><td>2.208980731666088e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ISEDTOT</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>DEPSCOURSAND</td><td>8.712720159441233</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>DEPSCOURSAND</td><td>0.012489795684814453</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>DEPSCOURSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>DEPSCOURCLAY</td><td>3.346940502524376e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>DEPSCOURTOT</td><td>8.712720159441233</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>ROSEDSAND</td><td>4.175938474945724</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>DEPSCOURTOT</td><td>0.012489795684814453</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>ROSEDSAND</td><td>0.003016233444213867</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ROSEDSILT</td><td>1.8285817304786178e-11</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ROSEDCLAY</td><td>2.1886080503463745e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>ROSEDTOT</td><td>4.175938474945724</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>OSEDSANDEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>OSEDSILTEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>OSEDCLAYEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>OSEDTOTEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
+<tr><td>-</td><td>ROSEDTOT</td><td>0.003016233444213867</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><th colspan=5 style="border:1px solid; background-color:#EEEEEE">RCHRES_GQUAL_004_2</th></tr>
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
-<tr><td>-</td><td>PESTICIDE B4DQAL</td><td>0.1638495922088623</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALSUSPSAND</td><td>1.0000000150474662e+30</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALSUSPSILT</td><td>0.006096098106348379</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALSUSPCLAY</td><td>0.006096099037670954</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALBEDSAND</td><td>1.0000000150474662e+30</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALBEDSILT</td><td>9.30482055991888e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALBEDCLAY</td><td>9.304878767579794e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RDQAL</td><td>0.00506201945245266</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSAND</td><td>0.0066098771121687605</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSILT</td><td>2.300155443888316e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPCLAY</td><td>0.00021118491713402162</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPTOT</td><td>0.006609735853999155</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDSAND</td><td>2.6184544563293457</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDSILT</td><td>0.24957776069641113</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDCLAY</td><td>0.24964189529418945</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDTOT</td><td>2.9403882026672363</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTSAND</td><td>2.614461123943329</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTSILT</td><td>0.24957776069641113</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTCLAY</td><td>0.24964189529418945</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTTOT</td><td>2.936708450317383</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RRQAL</td><td>2.940812110900879</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4IDQAL</td><td>3.203866071999073e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ISQALSAND</td><td>3.41015328686467e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ISQALSILT</td><td>1.0630507166736923e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ISQALCLAY</td><td>8.71699668566761e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ISQALTOT</td><td>8.71699668566761e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4TIQAL</td><td>8.685095235705376e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALHYDROL</td><td>0.001370520330965519</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALOXID</td><td>1.3705189303436782e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALPHOTOL</td><td>0.0011425515403971076</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALVOLAT</td><td>5.324120593286352e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALBIODEG</td><td>1.1745028132281732e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALGEN</td><td>2.349006535951048e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALTOT</td><td>0.0013942406512796879</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DQAL</td><td>0.0012650489807128906</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALSUSPSAND</td><td>1.4202669262886047e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALSUSPSILT</td><td>1.434236764907837e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALSUSPCLAY</td><td>1.5599653124809265e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALBEDSAND</td><td>6.548361852765083e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALBEDSILT</td><td>3.771856427192688e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALBEDCLAY</td><td>5.820766091346741e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RDQAL</td><td>1.7546117305755615e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSAND</td><td>1.4028511941432953e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSILT</td><td>9.393374966748524e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPCLAY</td><td>1.4581019058823586e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPTOT</td><td>1.4033867046236992e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDSAND</td><td>0.0002269744873046875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDSILT</td><td>0.0001010894775390625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDCLAY</td><td>0.000125885009765625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDTOT</td><td>0.0002593994140625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTSAND</td><td>0.0002193450927734375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTSILT</td><td>0.0001010894775390625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTCLAY</td><td>0.000125885009765625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTTOT</td><td>0.00025177001953125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RRQAL</td><td>0.0002593994140625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4IDQAL</td><td>4.3585896492004395e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ISQALSAND</td><td>3.232707967981696e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ISQALSILT</td><td>7.292833004157728e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ISQALCLAY</td><td>5.8353180065751076e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ISQALTOT</td><td>3.229797584936023e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4TIQAL</td><td>8.688820526003838e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALHYDROL</td><td>9.017821867018938e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALOXID</td><td>9.017782076625735e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALPHOTOL</td><td>1.0231276064587291e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALVOLAT</td><td>2.164840395835199e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALBIODEG</td><td>8.752820690460794e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALGEN</td><td>1.7505584537502727e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALTOT</td><td>1.5475088730454445e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQDECSUSPSAND</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQDECSUSPSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQDECSUSPCLAY</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDSAND</td><td>0.0001259191194549203</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDSILT</td><td>1.988897565752268e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDCLAY</td><td>1.9894348952220753e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDTOT</td><td>0.00014250300591811538</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALSUSPSAND</td><td>0.00271127122323378</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDSAND</td><td>3.8300640881061554e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDSILT</td><td>5.855690687894821e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDCLAY</td><td>5.8265868574380875e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDTOT</td><td>1.5529803931713104e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALSUSPSAND</td><td>1.097228960134089e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4ADQALSUSPSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALSUSPCLAY</td><td>0.000116602866910398</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALBEDSAND</td><td>0.007316495466511697</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALBEDSILT</td><td>0.001100592315196991</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALBEDCLAY</td><td>0.0011010728776454926</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALTOT</td><td>0.004950432106852531</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DSQALSAND</td><td>0.009590164540441037</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALSUSPCLAY</td><td>7.930793799459934e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALBEDSAND</td><td>1.9976869225502014e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALBEDSILT</td><td>2.1085143089294434e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALBEDCLAY</td><td>2.4847686290740967e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALTOT</td><td>4.190951585769653e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DSQALSAND</td><td>1.0611489415168762e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4DSQALSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DSQALCLAY</td><td>8.797905138626743e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DSQALTOT</td><td>0.009590164545443258</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RODQAL</td><td>0.0035738088190555573</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALSAND</td><td>0.0068935097216353824</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALSILT</td><td>8.661721118121908e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALCLAY</td><td>7.982987881397295e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALTOT</td><td>0.00689350876939443</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4TROQAL</td><td>0.003575456328690052</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DSQALCLAY</td><td>3.510649548843503e-10</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DSQALTOT</td><td>1.0611605830490589e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RODQAL</td><td>1.039355993270874e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALSAND</td><td>5.605746991932392e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALSILT</td><td>3.5416114485542494e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALCLAY</td><td>5.515175871551037e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALTOT</td><td>5.605630576610565e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4TROQAL</td><td>5.738809704780579e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><th colspan=5 style="border:1px solid; background-color:#EEEEEE">RCHRES_OXRX_004_2</th></tr>
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
 <tr><td>-</td><td>DOXCONC</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
@@ -1375,112 +1363,108 @@
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
 <tr><td>-</td><td>AIRTMP</td><td>7.62939453125e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>DEWTMP</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>TW</td><td>0.093505859375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>IHEAT</td><td>37001216.0</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>HTEXCH</td><td>2308044.0</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>ROHEAT</td><td>14643200.0</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>QTOTAL</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QSOLAR</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QLONGW</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QEVAP</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QCON</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QPREC</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>QBED</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
+<tr><td>-</td><td>TW</td><td>0.00580596923828125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>IHEAT</td><td>19552.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>HTEXCH</td><td>515968.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>ROHEAT</td><td>141312.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QTOTAL</td><td>0.1029815673828125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QSOLAR</td><td>3.0517578125e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QLONGW</td><td>0.007076263427734375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QEVAP</td><td>0.090087890625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QCON</td><td>0.01239013671875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QPREC</td><td>0.11358642578125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>QBED</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><th colspan=5 style="border:1px solid; background-color:#EEEEEE">RCHRES_SEDTRN_005_2</th></tr>
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
 <tr><td>-</td><td>SSEDSAND</td><td>0.00013518333435058594</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>SSEDSILT</td><td>0.005584716796875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>SSEDCLAY</td><td>3.917816162109375</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>SSEDTOT</td><td>3.022314549036573e+23</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>SSEDCLAY</td><td>0.005435943603515625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>SSEDTOT</td><td>0.01092529296875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDSUSPSAND</td><td>6.973743438720703e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDSUSPSILT</td><td>0.0008716583251953125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDSUSPCLAY</td><td>0.000835418701171875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDSUSPTOT</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>RSEDBEDSAND</td><td>887.27783203125</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>RSEDBEDSAND</td><td>0.016845703125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDBEDSILT</td><td>0.0021209716796875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDBEDCLAY</td><td>0.00146484375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDBEDTOT</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>RSEDTOTSAND</td><td>887.2779541015625</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>RSEDTOTSAND</td><td>0.016845703125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDTOTSILT</td><td>0.00250244140625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>RSEDTOTCLAY</td><td>0.002166748046875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>RSEDTOTTOT</td><td>887.27978515625</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>BEDDEP</td><td>0.509230375289917</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>ISEDSAND</td><td>4.175938474014401</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>RSEDTOTTOT</td><td>0.019775390625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>BEDDEP</td><td>1.1801719665527344e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>ISEDSAND</td><td>0.0030161142349243164</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ISEDSILT</td><td>0.0008716583251953125</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ISEDCLAY</td><td>0.0008335113525390625</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ISEDTOT</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>DEPSCOURSAND</td><td>4.175938693806529</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>DEPSCOURSAND</td><td>0.0030161142349243164</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>DEPSCOURSILT</td><td>4.756450653076172e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>DEPSCOURCLAY</td><td>0.00013017654418945312</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>DEPSCOURTOT</td><td>4.175938229076564</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>DEPSCOURTOT</td><td>0.0030161142349243164</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ROSEDSAND</td><td>2.689659595489502e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ROSEDSILT</td><td>0.00038814544677734375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ROSEDCLAY</td><td>0.0003719329833984375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>ROSEDTOT</td><td>0.000759124755859375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>OSEDSANDEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>OSEDSILTEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>OSEDCLAYEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
-<tr><td>-</td><td>OSEDTOTEXIT1</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>
 <tr><th colspan=5 style="border:1px solid; background-color:#EEEEEE">RCHRES_GQUAL_005_2</th></tr>
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
-<tr><td>-</td><td>PESTICIDE B4DQAL</td><td>0.03134727478027344</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALSUSPSAND</td><td>0.00027445497107692063</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALSUSPSILT</td><td>0.006096097594812968</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALSUSPCLAY</td><td>0.005664916927344166</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALBEDSAND</td><td>2.9545335564762354e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALBEDSILT</td><td>1.7206126358360052e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQALBEDCLAY</td><td>1.7311074770987034e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RDQAL</td><td>0.005188446491956711</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSAND</td><td>0.0002840528904926032</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSILT</td><td>0.00041005853563547134</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPCLAY</td><td>0.0004187228623777628</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALSUSPTOT</td><td>0.0008301767520606518</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDSAND</td><td>0.8566174507141113</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDSILT</td><td>0.09610366821289062</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDCLAY</td><td>0.09261846542358398</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALBEDTOT</td><td>0.6798458099365234</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTSAND</td><td>0.8566181659698486</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTSILT</td><td>0.09610366821289062</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTCLAY</td><td>0.09261846542358398</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RSQALTOTTOT</td><td>0.6798458099365234</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RRQAL</td><td>0.6796293258666992</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4IDQAL</td><td>0.0035738088190555573</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ISQALSAND</td><td>0.0068935097216353824</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ISQALSILT</td><td>8.661721118121908e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ISQALCLAY</td><td>7.982987881397295e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ISQALTOT</td><td>0.00689350876939443</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4TIQAL</td><td>0.0035754572600126266</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALHYDROL</td><td>0.0040025245398283005</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALOXID</td><td>4.002518835477531e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALPHOTOL</td><td>0.00031544058583676815</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALVOLAT</td><td>1.5758696463308297e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALBIODEG</td><td>3.7734171201009303e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALGEN</td><td>7.546841516159475e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DDQALTOT</td><td>0.058546893298625946</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DQAL</td><td>0.00021123886108398438</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALSUSPSAND</td><td>2.577435225248337e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALSUSPSILT</td><td>1.41095370054245e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALSUSPCLAY</td><td>2.621673047542572e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALBEDSAND</td><td>5.3551048040390015e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALBEDSILT</td><td>2.952292561531067e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQALBEDCLAY</td><td>2.3697793949395418e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RDQAL</td><td>9.804964065551758e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSAND</td><td>4.786706995218992e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPSILT</td><td>3.045424818992615e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPCLAY</td><td>3.5297125577926636e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALSUSPTOT</td><td>5.820766091346741e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDSAND</td><td>0.00026702880859375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDSILT</td><td>0.00157928466796875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDCLAY</td><td>0.00012674927711486816</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALBEDTOT</td><td>0.0013885498046875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTSAND</td><td>0.00026702880859375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTSILT</td><td>0.001583099365234375</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTCLAY</td><td>0.00012674927711486816</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RSQALTOTTOT</td><td>0.0013885498046875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RRQAL</td><td>0.0013885498046875</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4IDQAL</td><td>1.039355993270874e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ISQALSAND</td><td>5.605746991932392e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ISQALSILT</td><td>3.5416114485542494e-12</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ISQALCLAY</td><td>5.515175871551037e-09</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ISQALTOT</td><td>5.605630576610565e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4TIQAL</td><td>0.006896469742059708</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALHYDROL</td><td>6.954208947718143e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALOXID</td><td>6.954223863431253e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALPHOTOL</td><td>7.41715484764427e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALVOLAT</td><td>2.1074242795293685e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALBIODEG</td><td>9.01715111467638e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALGEN</td><td>1.8034256754617672e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DDQALTOT</td><td>8.301809430122375e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQDECSUSPSAND</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQDECSUSPSILT</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><td>-</td><td>PESTICIDE B4SQDECSUSPCLAY</td><td>0.0</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDSAND</td><td>5.8070429076906294e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDSILT</td><td>5.505426088348031e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDCLAY</td><td>5.313690053299069e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4SQDECBEDTOT</td><td>5.9865182265639305e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALSUSPSAND</td><td>0.0004804911841347348</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALSUSPSILT</td><td>0.0002683268394321203</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALSUSPCLAY</td><td>0.0002889225725084543</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALBEDSAND</td><td>0.005016936920583248</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALBEDSILT</td><td>0.0007793065160512924</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALBEDCLAY</td><td>0.0007492378354072571</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ADQALTOT</td><td>0.005196277052164078</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DSQALSAND</td><td>0.0009458456333959475</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DSQALSILT</td><td>4.534982144832611e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DSQALCLAY</td><td>0.0001223403960466385</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4DSQALTOT</td><td>0.0009458456333959475</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4RODQAL</td><td>0.002654384821653366</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALSAND</td><td>0.0006329765456030145</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALSILT</td><td>0.00017797842156141996</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALCLAY</td><td>0.00017987238243222237</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4ROSQALTOT</td><td>0.0007448620162904263</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
-<tr><td>-</td><td>PESTICIDE B4TROQAL</td><td>0.012102708220481873</td><td><span style="font-weight:bold;color:red">X</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDSAND</td><td>1.1466909199953079e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDSILT</td><td>1.2479722499847412e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDCLAY</td><td>1.284060999751091e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4SQDECBEDTOT</td><td>3.67872416973114e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALSUSPSAND</td><td>8.220085874199867e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALSUSPSILT</td><td>2.4028122425079346e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALSUSPCLAY</td><td>1.0998919606208801e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALBEDSAND</td><td>4.16487455368042e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALBEDSILT</td><td>7.890164852142334e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALBEDCLAY</td><td>6.042420864105225e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ADQALTOT</td><td>1.6376376152038574e-05</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DSQALSAND</td><td>5.605397745966911e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DSQALSILT</td><td>6.239861249923706e-08</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DSQALCLAY</td><td>1.432374119758606e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4DSQALTOT</td><td>5.605281330645084e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4RODQAL</td><td>6.183981895446777e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALSAND</td><td>9.885989129543304e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALSILT</td><td>1.9208528101444244e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALCLAY</td><td>1.862645149230957e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4ROSQALTOT</td><td>8.619390428066254e-07</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
+<tr><td>-</td><td>PESTICIDE B4TROQAL</td><td>6.198883056640625e-06</td><td><span style="font-weight:bold;color:green">&#10003;</span></td><td></td></tr>
 <tr><th colspan=5 style="border:1px solid; background-color:#EEEEEE">RCHRES_OXRX_005_2</th></tr>
 <tr><th></th><th style="text-align:left">Constituent</th><th style="text-align:left">Max Diff</th><th>Match</th><th>Note</th></tr>
 <tr><td>-</td><td>DOXCONC</td><td>NA</td><td>NA</td><td>not in h5<br></td></tr>


### PR DESCRIPTION
In anticipation of a PR from us, Respec just released all of their improvements and bug fixes to https://github.com/respec/HSPsquared/releases/tag/0.9.2.

After we merge this, we should update `HSP2/__init__.py` to the next version number: `0.10.0`